### PR TITLE
Pass environment variables to the JS app

### DIFF
--- a/packages/fuse-box-react-scripts/config/env.js
+++ b/packages/fuse-box-react-scripts/config/env.js
@@ -1,0 +1,50 @@
+// @remove-on-eject-begin
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+// @remove-on-eject-end
+'use strict';
+
+// Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
+// injected into the application via DefinePlugin in Webpack configuration.
+const REACT_APP = /^REACT_APP_/i;
+
+function getClientEnvironment(publicUrl) {
+  const raw = Object.keys(process.env)
+    .filter(key => REACT_APP.test(key))
+    .reduce(
+      (env, key) => {
+        env[key] = process.env[key];
+        return env;
+      },
+      {
+        // Useful for determining whether we’re running in production mode.
+        // Most importantly, it switches React into the correct mode.
+        NODE_ENV: process.env.NODE_ENV || 'development',
+        // Useful for resolving the correct path to static assets in `public`.
+        // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
+        // This should only be used as an escape hatch. Normally you would put
+        // images into the `src` and `import` them in code to get their paths.
+        PUBLIC_URL: publicUrl,
+      }
+    );
+  // Stringify all values so we can feed into Webpack DefinePlugin
+  const stringified = {
+    'process.env': Object.keys(raw).reduce(
+      (env, key) => {
+        env[key] = JSON.stringify(raw[key]);
+        return env;
+      },
+      {}
+    ),
+  };
+
+  return { raw, stringified };
+}
+
+module.exports = getClientEnvironment;

--- a/packages/fuse-box-react-scripts/config/fuse.config.dev.js
+++ b/packages/fuse-box-react-scripts/config/fuse.config.dev.js
@@ -1,6 +1,6 @@
 // @remove-on-eject-begin
 /**
- * Copyright (c) 2017-present, Off Grid Networks. 
+ * Copyright (c) 2017-present, Off Grid Networks.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -11,6 +11,7 @@
 
 const fsbx = require("fuse-box"),
     FuseBox = fsbx.FuseBox,
+    env = require('./env')(),
     path = require('path');
 
 exports.initBuilder = function initBuilderDev(paths, bundleFile, srcDir, targetDir) {
@@ -21,9 +22,7 @@ exports.initBuilder = function initBuilderDev(paths, bundleFile, srcDir, targetD
         homeDir: srcDir,
         outFile: path.join(targetDir, bundleFile),
         plugins: [
-            fsbx.EnvPlugin({
-                "NODE_ENV": process.env.NODE_ENV
-            }),
+            fsbx.EnvPlugin(env.raw),
             fsbx.SVGPlugin(),
             fsbx.CSSPlugin(),
             fsbx.HTMLPlugin({ useDefault: false }),

--- a/packages/fuse-box-react-scripts/config/fuse.config.prod.js
+++ b/packages/fuse-box-react-scripts/config/fuse.config.prod.js
@@ -1,6 +1,6 @@
 // @remove-on-eject-begin
 /**
- * Copyright (c) 2017-present, Off Grid Networks. 
+ * Copyright (c) 2017-present, Off Grid Networks.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -11,6 +11,7 @@
 
 const fsbx = require("fuse-box"),
     FuseBox = fsbx.FuseBox,
+    env = require('./env')(),
     path = require('path');
 
 exports.initBuilder = function initBuilderProd(paths, bundleFile, srcDir, targetDir) {
@@ -22,9 +23,7 @@ exports.initBuilder = function initBuilderProd(paths, bundleFile, srcDir, target
         sourceMaps: true,
         outFile: path.join(targetDir, bundleFile),
         plugins: [
-            fsbx.EnvPlugin({
-                "NODE_ENV": process.env.NODE_ENV
-            }),
+            fsbx.EnvPlugin(env.raw),
             fsbx.SVGPlugin(),
             fsbx.CSSPlugin(),
             fsbx.HTMLPlugin({ useDefault: false }),


### PR DESCRIPTION
make the REACT_APP_* environment variables available in the JS app,
as mentioned in the README:
https://github.com/offgridnetworks/fuse-box-create-react-app/blob/master/packages/fuse-box-react-scripts/template/README.md#adding-custom-environment-variables

It's basically copy->pasting from https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/env.js . 