### PR TITLE
Fixed dereferencing null childPackage.dependencies on eject

### DIFF
--- a/packages/fuse-box-react-scripts/scripts/eject.js
+++ b/packages/fuse-box-react-scripts/scripts/eject.js
@@ -176,17 +176,19 @@ inquirer
             ownDependency,
             'package.json'
           ));
-          Object.keys(childPackage.dependencies).forEach(key => {
-            // For some reason optionalDependencies end up in dependencies after install
-            if (
-              childPackage.optionalDependencies &&
-              childPackage.optionalDependencies[key]
-            ) {
-              return;
-            }
-            console.log(`  Adding ${cyan(key)} to devDependencies`);
-            devDependenciesToAdd[key] = childPackage.dependencies[key];
-          });
+          if (childPackage.dependencies) {
+            Object.keys(childPackage.dependencies).forEach(key => {
+                // For some reason optionalDependencies end up in dependencies after install
+                if (
+                childPackage.optionalDependencies &&
+                childPackage.optionalDependencies[key]
+                ) {
+                return;
+                }
+                console.log(`  Adding ${cyan(key)} to devDependencies`);
+                devDependenciesToAdd[key] = childPackage.dependencies[key];
+            });
+          }
         }
       });
 


### PR DESCRIPTION
The eject script fails with the following output (i left some debug statements in there):
Updating the dependencies
  Removing appPackage fuse-box-react-scripts from devDependencies
  Removing ownPackage babel-core from devDependencies
  deleting appPackage.devDependencies[ownDependency] from devDependencies
{"babel-core":"7.0.0-bridge.0","fuse-box-react-scripts-babel":"^3.0.80"}
Cannot convert undefined or null to object
error Command failed with exit code 1.